### PR TITLE
fix/errormessage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,11 +97,11 @@ export default (WrappedComponent) => {
       const playerError = Platform.select({
         ios: {
           player_error_code: error.code,
-          player_error_message: error.localizedFailureReason
+          player_error_message: error?.localizedFailureReason || error?.localizedDescription,
         },
         android: {
           player_error_code: error.errorCode,
-          player_error_message: error.errorString
+          player_error_message: error?.errorException || error?.errorString,
         }
       })
 


### PR DESCRIPTION
안드로이드에서 source 를 임의로 넣어주고 로그를 살펴봤는데 errorException 이 디테일한것같아서 errorException 으로 변경하였습니다.

"errorCode": "22001"
"errorException": "com.google.android.exoplayer2.ExoPlaybackException: Source error"
"errorString": "ExoPlaybackException: ERROR_CODE_IO_NETWORK_CONNECTION_FAILED"


iOS 에서는 localizedDescription 가 빈값이 경우가 있어서 예외처리를 해주었습니다